### PR TITLE
Add KV certificate to complete example

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -14,5 +14,5 @@ data "azurerm_key_vault" "keyvault" {
   name                = var.apim_key_vault_name
   resource_group_name = var.apim_key_vault_resource_group_name
 
-  count = local.key_vault_enabled ? 1 : 0
+  count = var.apim_key_vault_enabled ? 1 : 0
 }

--- a/data.tf
+++ b/data.tf
@@ -9,3 +9,10 @@ data "azurerm_subnet" "subnet" {
 
   count = local.apim_vnet_enabled ? 1 : 0
 }
+
+data "azurerm_key_vault" "keyvault" {
+  name                = var.apim_key_vault_name
+  resource_group_name = var.apim_key_vault_resource_group_name
+
+  count = local.key_vault_enabled ? 1 : 0
+}

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -1,6 +1,1 @@
 data "azurerm_client_config" "current" {}
-
-data "azurerm_api_management" "apim" {
-  name                = module.apim.api_management.name
-  resource_group_name = azurerm_resource_group.test_group.name
-}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -172,9 +172,9 @@ module "apim" {
   apim_identity_type = "SystemAssigned"
   apim_identity_ids  = []
 
-  # Key Vault
+  apim_key_vault_enabled             = true # This can not be dynamically resolved due to: https://github.com/hashicorp/terraform/issues/21634
   apim_key_vault_name                = azurerm_key_vault.test_group.name
-  apim_key_vault_resource_group_name = azurerm_key_vault.test_group.resource_group_name
+  apim_key_vault_resource_group_name = azurerm_resource_group.test_group.name
 
   # Management
   apim_management_host_name                    = "mgmt.example.com"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -141,6 +141,7 @@ resource "azurerm_key_vault_certificate" "test_group" {
 module "apim" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.test_group.name
+  prefix              = [local.unique_name_stub]
   suffix              = [local.unique_name_stub]
 
   # API Management

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -128,7 +128,8 @@ resource "azurerm_key_vault_certificate" "test_group" {
           "dev.example.com",
           "mgmt.example.com",
           "scm.example.com",
-        "portal.example.com"]
+          "portal.example.com"
+        ]
       }
 
       subject            = "CN=*.example.com"
@@ -173,7 +174,7 @@ module "apim" {
   apim_identity_ids  = []
 
   apim_key_vault_enabled             = true # This can not be dynamically resolved due to: https://github.com/hashicorp/terraform/issues/21634
-  apim_key_vault_name                = azurerm_key_vault.test_group.name
+  apim_key_vault_name                = module.naming.key_vault.name_unique
   apim_key_vault_resource_group_name = azurerm_resource_group.test_group.name
 
   # Management

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~>2.0"
+  version = "~>2.13.0"
   features {}
 }
 
@@ -49,7 +49,26 @@ resource "azurerm_key_vault" "test_group" {
 
     secret_permissions = [
       "set",
-      "get"
+      "get",
+      "delete"
+    ]
+
+    certificate_permissions = [
+      "create",
+      "get",
+      "getissuers",
+      "setissuers",
+      "update",
+    ]
+
+    key_permissions = [
+      "create",
+      "decrypt",
+      "encrypt",
+      "import",
+      "sign",
+      "update",
+      "verify",
     ]
   }
 
@@ -59,41 +78,67 @@ resource "azurerm_key_vault" "test_group" {
   }
 }
 
-resource "tls_private_key" "test_group" {
-  algorithm   = "ECDSA"
-  ecdsa_curve = "P384"
-}
-
-resource "tls_self_signed_cert" "test_group" {
-  key_algorithm   = "ECDSA"
-  private_key_pem = tls_private_key.test_group.private_key_pem
-
-  subject {
-    common_name  = "*.example.com"
-    organization = "ACME Examples, Inc"
-  }
-
-  validity_period_hours = 12
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
-}
-
-resource "azurerm_key_vault_secret" "test_group" {
-  name         = "apimcertificate"
-  value        = base64encode(tls_self_signed_cert.test_group.cert_pem)
+resource "azurerm_key_vault_certificate" "test_group" {
+  name         = "generated-cert"
   key_vault_id = azurerm_key_vault.test_group.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      # Server Authentication = 1.3.6.1.5.5.7.3.1
+      # Client Authentication = 1.3.6.1.5.5.7.3.2
+      extended_key_usage = ["1.3.6.1.5.5.7.3.1"]
+
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject_alternative_names {
+        dns_names = [
+          "dev2.example.com",
+          "mgmt.example.com",
+          "scm.example.com",
+        "portal.example.com"]
+      }
+
+      subject            = "CN=*.example.com"
+      validity_in_months = 12
+    }
+  }
 }
 
-# UserAssigned identities cannot be used with Key Vault
-# https://feedback.azure.com/forums/248703-api-management/suggestions/38047561-support-for-user-assigned-managed-identity
 module "apim" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.test_group.name
-  prefix              = [local.unique_name_stub]
   suffix              = [local.unique_name_stub]
 
   # API Management
@@ -125,15 +170,30 @@ module "apim" {
 
   apim_identity_type = "SystemAssigned"
   apim_identity_ids  = []
-}
 
-resource "azurerm_key_vault_access_policy" "apim" {
-  key_vault_id = azurerm_key_vault.test_group.id
+  # Key Vault
+  apim_key_vault_name                = azurerm_key_vault.test_group.name
+  apim_key_vault_resource_group_name = azurerm_key_vault.test_group.resource_group_name
 
-  tenant_id = module.apim.api_management.identity[0].tenant_id
-  object_id = module.apim.api_management.identity[0].principal_id
+  # Management
+  apim_management_host_name                    = "mgmt.example.com"
+  apim_management_key_vault_id                 = azurerm_key_vault_certificate.test_group.secret_id
+  apim_management_negotiate_client_certificate = false
 
-  secret_permissions = [
-    "get",
-  ]
+  # Portal
+  apim_portal_host_name                    = "portal.example.com"
+  apim_portal_key_vault_id                 = azurerm_key_vault_certificate.test_group.secret_id
+  apim_portal_negotiate_client_certificate = false
+
+  # Dev Portal
+  apim_developer_portal_host_name                    = "dev2.example.com"
+  apim_developer_portal_key_vault_id                 = azurerm_key_vault_certificate.test_group.secret_id
+  apim_developer_portal_negotiate_client_certificate = false
+
+  # SCM
+  apim_scm_host_name                    = "scm.example.com"
+  apim_scm_key_vault_id                 = azurerm_key_vault_certificate.test_group.secret_id
+  apim_scm_negotiate_client_certificate = false
+
+  module_depends_on = []
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -59,6 +59,7 @@ resource "azurerm_key_vault" "test_group" {
       "getissuers",
       "setissuers",
       "update",
+      "delete"
     ]
 
     key_permissions = [
@@ -124,7 +125,7 @@ resource "azurerm_key_vault_certificate" "test_group" {
 
       subject_alternative_names {
         dns_names = [
-          "dev2.example.com",
+          "dev.example.com",
           "mgmt.example.com",
           "scm.example.com",
         "portal.example.com"]
@@ -186,7 +187,7 @@ module "apim" {
   apim_portal_negotiate_client_certificate = false
 
   # Dev Portal
-  apim_developer_portal_host_name                    = "dev2.example.com"
+  apim_developer_portal_host_name                    = "dev.example.com"
   apim_developer_portal_key_vault_id                 = azurerm_key_vault_certificate.test_group.secret_id
   apim_developer_portal_negotiate_client_certificate = false
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~>2.0"
+  version = "2.13.0"
   features {}
 }
 
@@ -10,42 +10,32 @@ resource "null_resource" "module_depends_on" {
 }
 
 locals {
-  apim_vnet_type        = var.apim_virtual_network_type
-  apim_vnet_enabled     = local.apim_vnet_type != "None"
-  apim_identity_enabled = var.apim_identity_type != ""
-  apim_management_enabled = length(
-    format("%s%s%s%s",
-      var.apim_management_host_name,
-      var.apim_management_key_vault_id,
-      var.apim_management_certificate,
-  var.apim_management_certificate_password)) > 0
-  apim_portal_enabled = length(
-    format("%s%s%s%s",
-      var.apim_portal_host_name,
-      var.apim_portal_key_vault_id,
-      var.apim_portal_certificate,
-  var.apim_portal_certificate_password)) > 0
-  apim_developer_portal_enabled = length(
-    format("%s%s%s%s",
-      var.apim_developer_portal_host_name,
-      var.apim_developer_portal_key_vault_id,
-      var.apim_developer_portal_certificate,
-  var.apim_developer_portal_certificate_password)) > 0
-  apim_scm_enabled = length(
-    format("%s%s%s%s",
-      var.apim_scm_host_name,
-      var.apim_scm_key_vault_id,
-      var.apim_scm_certificate,
-  var.apim_scm_certificate_password)) > 0
-  hostname_configuration_enabled = local.apim_management_enabled || local.apim_developer_portal_enabled || local.apim_portal_enabled || local.apim_scm_enabled
+  apim_vnet_type                      = var.apim_virtual_network_type
+  apim_vnet_enabled                   = local.apim_vnet_type != "None"
+  apim_identity_enabled               = var.apim_identity_type != ""
+  apim_management_cert_enabled        = var.apim_management_host_name != "" && var.apim_management_certificate != "" && var.apim_management_certificate_password != ""
+  apim_portal_cert_enabled            = var.apim_portal_host_name != "" && var.apim_portal_certificate != "" && var.apim_portal_certificate_password != ""
+  apim_developer_portal_cert_enabled  = var.apim_developer_portal_host_name != "" && var.apim_developer_portal_certificate != "" && var.apim_developer_portal_certificate_password != ""
+  apim_scm_cert_enabled               = var.apim_scm_host_name != "" && var.apim_scm_certificate != "" && var.apim_scm_certificate_password != ""
+  hostname_configuration_cert_enabled = local.apim_management_cert_enabled || local.apim_developer_portal_cert_enabled || local.apim_portal_cert_enabled || local.apim_scm_cert_enabled
+  key_vault_enabled                   = var.apim_key_vault_name != "" && var.apim_key_vault_resource_group_name != ""
 }
 
 module "naming" {
   source = "git::https://github.com/Azure/terraform-azurerm-naming"
   suffix = var.suffix
-  prefix = var.prefix
 }
 
+# UserAssigned identities are currently in preview but don't seem to be working
+# yet for accessing key vault secrets/certificates. We therefore, only define
+# hostname configuration if you're using a APIM certificate directly rather 
+# than an Azure Key Vault certificate. If you are using an Azure Key Vault
+# certificate then the honstame configuration will be applied after the
+# SystemAssigned MSI has been given access to the Azure Key Vault.
+# Related issues:
+# - https://github.com/terraform-providers/terraform-provider-azurerm/issues/3058
+# - https://github.com/terraform-providers/terraform-provider-azurerm/issues/3635
+# - https://feedback.azure.com/forums/248703-api-management/suggestions/38047561-support-for-user-assigned-managed-identity
 resource "azurerm_api_management" "apim" {
   name                = module.naming.api_management.name_unique
   location            = data.azurerm_resource_group.base.location
@@ -89,15 +79,14 @@ resource "azurerm_api_management" "apim" {
   }
 
   dynamic "hostname_configuration" {
-    for_each = local.hostname_configuration_enabled ? [1] : []
+    for_each = local.hostname_configuration_cert_enabled ? [1] : []
 
     content {
       dynamic "management" {
-        for_each = local.apim_management_enabled ? [1] : []
+        for_each = local.apim_management_cert_enabled ? [1] : []
 
         content {
           host_name                    = length(var.apim_management_host_name) > 0 ? var.apim_management_host_name : null
-          key_vault_id                 = length(var.apim_management_key_vault_id) > 0 ? var.apim_management_key_vault_id : null
           certificate                  = length(var.apim_management_certificate) > 0 ? var.apim_management_certificate : null
           certificate_password         = length(var.apim_management_certificate_password) > 0 ? var.apim_management_certificate_password : null
           negotiate_client_certificate = var.apim_management_negotiate_client_certificate
@@ -105,11 +94,10 @@ resource "azurerm_api_management" "apim" {
       }
 
       dynamic "portal" {
-        for_each = local.apim_portal_enabled ? [1] : []
+        for_each = local.apim_portal_cert_enabled ? [1] : []
 
         content {
           host_name                    = length(var.apim_portal_host_name) > 0 ? var.apim_portal_host_name : null
-          key_vault_id                 = length(var.apim_portal_key_vault_id) > 0 ? var.apim_portal_key_vault_id : null
           certificate                  = length(var.apim_portal_certificate) > 0 ? var.apim_portal_certificate : null
           certificate_password         = length(var.apim_portal_certificate_password) > 0 ? var.apim_portal_certificate_password : null
           negotiate_client_certificate = var.apim_portal_negotiate_client_certificate
@@ -117,11 +105,10 @@ resource "azurerm_api_management" "apim" {
       }
 
       dynamic "developer_portal" {
-        for_each = local.apim_developer_portal_enabled ? [1] : []
+        for_each = local.apim_developer_portal_cert_enabled ? [1] : []
 
         content {
           host_name                    = length(var.apim_developer_portal_host_name) > 0 ? var.apim_developer_portal_host_name : null
-          key_vault_id                 = length(var.apim_developer_portal_key_vault_id) > 0 ? var.apim_developer_portal_key_vault_id : null
           certificate                  = length(var.apim_developer_portal_certificate) > 0 ? var.apim_developer_portal_certificate : null
           certificate_password         = length(var.apim_developer_portal_certificate_password) > 0 ? var.apim_developer_portal_certificate_password : null
           negotiate_client_certificate = var.apim_developer_portal_negotiate_client_certificate
@@ -129,11 +116,10 @@ resource "azurerm_api_management" "apim" {
       }
 
       dynamic "scm" {
-        for_each = local.apim_scm_enabled ? [1] : []
+        for_each = local.apim_scm_cert_enabled ? [1] : []
 
         content {
           host_name                    = length(var.apim_scm_host_name) > 0 ? var.apim_scm_host_name : null
-          key_vault_id                 = length(var.apim_scm_key_vault_id) > 0 ? var.apim_scm_key_vault_id : null
           certificate                  = length(var.apim_scm_certificate) > 0 ? var.apim_scm_certificate : null
           certificate_password         = length(var.apim_scm_certificate_password) > 0 ? var.apim_scm_certificate_password : null
           negotiate_client_certificate = var.apim_scm_negotiate_client_certificate
@@ -145,23 +131,39 @@ resource "azurerm_api_management" "apim" {
   depends_on = [null_resource.module_depends_on]
 }
 
-# TODO: Do we need this or does diagnostics work ok?
-# resource "azurerm_api_management_logger" "apim" {
-#   name                = var.apim_logger_name
-#   api_management_name = azurerm_api_management.apim.name
-#   resource_group_name = data.azurerm_resource_group.base.name
+resource "azurerm_key_vault_access_policy" "apim" {
+  count = local.key_vault_enabled ? 1 : 0
 
-#   application_insights {
-#     instrumentation_key = azurerm_application_insights.example.instrumentation_key
-#   }
-# }
+  key_vault_id = data.azurerm_key_vault.keyvault[0].id
 
-# resource "azurerm_api_management_diagnostic" "apim" {
-#   identifier               = "loganalytics"
-#   resource_group_name      = azurerm_resource_group.example.name
-#   api_management_name      = azurerm_api_management.example.name
-#   api_management_logger_id = azurerm_api_management_logger.example.id
-# }
+  tenant_id = azurerm_api_management.apim.identity[0].tenant_id
+  object_id = azurerm_api_management.apim.identity[0].principal_id
+
+  secret_permissions = [
+    "get",
+  ]
+
+  # TODO: Remove once UserAssigned MSI work with APIM + KeyVault
+  provisioner "local-exec" {
+    command = format("%s/scripts/host_config.sh %s %s %s %s %s %s %s %s %s %s %s %s %s %s",
+      path.module,
+      azurerm_api_management.apim.name,
+      azurerm_api_management.apim.resource_group_name,
+      var.apim_management_host_name,
+      var.apim_management_key_vault_id,
+      var.apim_management_negotiate_client_certificate,
+      var.apim_portal_host_name,
+      var.apim_portal_key_vault_id,
+      var.apim_portal_negotiate_client_certificate,
+      var.apim_developer_portal_host_name,
+      var.apim_developer_portal_key_vault_id,
+      var.apim_developer_portal_negotiate_client_certificate,
+      var.apim_scm_host_name,
+      var.apim_scm_key_vault_id,
+      var.apim_scm_negotiate_client_certificate
+    )
+  }
+}
 
 resource "azurerm_api_management_authorization_server" "apim" {
   name                         = var.apim_authorization_server_name

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ locals {
 module "naming" {
   source = "git::https://github.com/Azure/terraform-azurerm-naming"
   suffix = var.suffix
+  prefix = var.prefix
 }
 
 # UserAssigned identities are currently in preview but don't seem to be working

--- a/scripts/host_config.sh
+++ b/scripts/host_config.sh
@@ -34,28 +34,28 @@ fi
 CURR_CONFIG=$(az apim show -n ${APIM_SVC_NAME} -g ${APIM_RESOURCE_GROUP_NAME} --query 'hostnameConfigurations')
 
 if ! [ -z ${MGMT_HOST_NAME} ] && ! [ -z ${MGMT_KEY_VAULT_ID} ]; then
-    echo "Add management host configuration"
+    echo "Set management host configuration"
     MGMT_CONFIG="[{\"type\":\"Management\",\"hostName\":\"${MGMT_HOST_NAME}\",\"keyVaultId\":\"${MGMT_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${MGMT_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
     # MGMT_CONFIG takes precedence over existing values on conflict
     CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$MGMT_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
 fi
 
 if ! [ -z ${PORTAL_HOST_NAME} ] && ! [ -z ${PORTAL_KEY_VAULT_ID} ]; then
-    echo "Add portal host configuration"
+    echo "Set portal host configuration"
     PORTAL_CONFIG="[{\"type\":\"Portal\",\"hostName\":\"${PORTAL_HOST_NAME}\",\"keyVaultId\":\"${PORTAL_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${PORTAL_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
     # PORTAL_CONFIG takes precedence over existing values on conflict
     CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$PORTAL_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
 fi
 
 if ! [ -z ${DEVELOPER_PORTAL_HOST_NAME} ] && ! [ -z ${DEVELOPER_PORTAL_KEY_VAULT_ID} ]; then
-    echo "Add developer portal host configuration"
+    echo "Set developer portal host configuration"
     DEVELOPER_PORTAL_CONFIG="[{\"type\":\"DeveloperPortal\",\"hostName\":\"${DEVELOPER_PORTAL_HOST_NAME}\",\"keyVaultId\":\"${DEVELOPER_PORTAL_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${DEVELOPER_PORTAL_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
     # DEVELOPER_PORTAL_CONFIG takes precedence over existing values on conflict
     CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$DEVELOPER_PORTAL_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
 fi
 
 if ! [ -z ${SCM_HOST_NAME} ] && ! [ -z ${SCM_KEY_VAULT_ID} ]; then
-    echo "Add scm host configuration"
+    echo "Set scm host configuration"
     SCM_CONFIG="[{\"type\":\"Management\",\"hostName\":\"${SCM_HOST_NAME}\",\"keyVaultId\":\"${SCM_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${SCM_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
     # SCM_CONFIG takes precedence over existing values on conflict
     CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$SCM_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')

--- a/scripts/host_config.sh
+++ b/scripts/host_config.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# This is a temporary script required to enable API Management
+# to set the host configuraiton using Azure Key Vault references
+# whilst there is not support for UserAssigned Manage Service
+# Identities for Key Vault Access in the Terraform Provider.
+
+set -e
+
+APIM_SVC_NAME=${1}
+APIM_RESOURCE_GROUP_NAME=${2}
+
+MGMT_HOST_NAME=${3}
+MGMT_KEY_VAULT_ID=${4}
+MGMT_NEGOTIATE_CLIENT_CERT=${5}
+
+PORTAL_HOST_NAME=${6}
+PORTAL_KEY_VAULT_ID=${7}
+PORTAL_NEGOTIATE_CLIENT_CERT=${8}
+
+DEVELOPER_PORTAL_HOST_NAME=${9}
+DEVELOPER_PORTAL_KEY_VAULT_ID=${10}
+DEVELOPER_PORTAL_NEGOTIATE_CLIENT_CERT=${11}
+
+SCM_HOST_NAME=${12}
+SCM_KEY_VAULT_ID=${13}
+SCM_NEGOTIATE_CLIENT_CERT=${14}
+
+if [ -z ${APIM_SVC_NAME} ] || [ -z ${APIM_RESOURCE_GROUP_NAME} ]; then
+    echo "APIM_SVC_NAME and APIM_RESOURCE_GROUP_NAME args are required!"
+    exit 1
+fi
+
+CURR_CONFIG=$(az apim show -n ${APIM_SVC_NAME} -g ${APIM_RESOURCE_GROUP_NAME} --query 'hostnameConfigurations')
+
+if ! [ -z ${MGMT_HOST_NAME} ] && ! [ -z ${MGMT_KEY_VAULT_ID} ]; then
+    echo "Add management host configuration"
+    MGMT_CONFIG="[{\"type\":\"Management\",\"hostName\":\"${MGMT_HOST_NAME}\",\"keyVaultId\":\"${MGMT_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${MGMT_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
+    # MGMT_CONFIG takes precedence over existing values on conflict
+    CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$MGMT_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
+fi
+
+if ! [ -z ${PORTAL_HOST_NAME} ] && ! [ -z ${PORTAL_KEY_VAULT_ID} ]; then
+    echo "Add portal host configuration"
+    PORTAL_CONFIG="[{\"type\":\"Portal\",\"hostName\":\"${PORTAL_HOST_NAME}\",\"keyVaultId\":\"${PORTAL_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${PORTAL_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
+    # PORTAL_CONFIG takes precedence over existing values on conflict
+    CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$PORTAL_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
+fi
+
+if ! [ -z ${DEVELOPER_PORTAL_HOST_NAME} ] && ! [ -z ${DEVELOPER_PORTAL_KEY_VAULT_ID} ]; then
+    echo "Add developer portal host configuration"
+    DEVELOPER_PORTAL_CONFIG="[{\"type\":\"DeveloperPortal\",\"hostName\":\"${DEVELOPER_PORTAL_HOST_NAME}\",\"keyVaultId\":\"${DEVELOPER_PORTAL_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${DEVELOPER_PORTAL_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
+    # DEVELOPER_PORTAL_CONFIG takes precedence over existing values on conflict
+    CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$DEVELOPER_PORTAL_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
+fi
+
+if ! [ -z ${SCM_HOST_NAME} ] && ! [ -z ${SCM_KEY_VAULT_ID} ]; then
+    echo "Add scm host configuration"
+    SCM_CONFIG="[{\"type\":\"Management\",\"hostName\":\"${SCM_HOST_NAME}\",\"keyVaultId\":\"${SCM_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${SCM_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
+    # SCM_CONFIG takes precedence over existing values on conflict
+    CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$SCM_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
+fi
+
+CURR_CONFIG=$(echo "${CURR_CONFIG}" | jq -c .)
+az apim update -g ${APIM_RESOURCE_GROUP_NAME} -n ${APIM_SVC_NAME} --set hostnameConfigurations="${CURR_CONFIG}"
+echo "Set host configuration"
+

--- a/scripts/host_config.sh
+++ b/scripts/host_config.sh
@@ -33,30 +33,30 @@ fi
 
 CURR_CONFIG=$(az apim show -n ${APIM_SVC_NAME} -g ${APIM_RESOURCE_GROUP_NAME} --query 'hostnameConfigurations')
 
-if ! [ -z ${MGMT_HOST_NAME} ] && ! [ -z ${MGMT_KEY_VAULT_ID} ]; then
+if ! [ -z ${MGMT_HOST_NAME} ] && [ ${MGMT_KEY_VAULT_ID} != "-" ]; then
     echo "Set management host configuration"
     MGMT_CONFIG="[{\"type\":\"Management\",\"hostName\":\"${MGMT_HOST_NAME}\",\"keyVaultId\":\"${MGMT_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${MGMT_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
     # MGMT_CONFIG takes precedence over existing values on conflict
     CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$MGMT_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
 fi
 
-if ! [ -z ${PORTAL_HOST_NAME} ] && ! [ -z ${PORTAL_KEY_VAULT_ID} ]; then
+if ! [ -z ${PORTAL_HOST_NAME} ] && [ ${PORTAL_KEY_VAULT_ID} != "-" ]; then
     echo "Set portal host configuration"
     PORTAL_CONFIG="[{\"type\":\"Portal\",\"hostName\":\"${PORTAL_HOST_NAME}\",\"keyVaultId\":\"${PORTAL_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${PORTAL_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
     # PORTAL_CONFIG takes precedence over existing values on conflict
     CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$PORTAL_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
 fi
 
-if ! [ -z ${DEVELOPER_PORTAL_HOST_NAME} ] && ! [ -z ${DEVELOPER_PORTAL_KEY_VAULT_ID} ]; then
+if ! [ -z ${DEVELOPER_PORTAL_HOST_NAME} ] && [ ${DEVELOPER_PORTAL_KEY_VAULT_ID} != "-" ]; then
     echo "Set developer portal host configuration"
     DEVELOPER_PORTAL_CONFIG="[{\"type\":\"DeveloperPortal\",\"hostName\":\"${DEVELOPER_PORTAL_HOST_NAME}\",\"keyVaultId\":\"${DEVELOPER_PORTAL_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${DEVELOPER_PORTAL_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
     # DEVELOPER_PORTAL_CONFIG takes precedence over existing values on conflict
     CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$DEVELOPER_PORTAL_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
 fi
 
-if ! [ -z ${SCM_HOST_NAME} ] && ! [ -z ${SCM_KEY_VAULT_ID} ]; then
+if ! [ -z ${SCM_HOST_NAME} ] && [ ${SCM_KEY_VAULT_ID} != "-" ]; then
     echo "Set scm host configuration"
-    SCM_CONFIG="[{\"type\":\"Management\",\"hostName\":\"${SCM_HOST_NAME}\",\"keyVaultId\":\"${SCM_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${SCM_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
+    SCM_CONFIG="[{\"type\":\"Scm\",\"hostName\":\"${SCM_HOST_NAME}\",\"keyVaultId\":\"${SCM_KEY_VAULT_ID}\",\"negotiateClientCertificate\":${SCM_NEGOTIATE_CLIENT_CERT}, \"defaultSslBinding\": false}]"
     # SCM_CONFIG takes precedence over existing values on conflict
     CURR_CONFIG=$(jq --argjson arr1 "$CURR_CONFIG" --argjson arr2 "$SCM_CONFIG" -n '$arr2 + $arr1 | unique_by(.type)')
 fi

--- a/variables.tf
+++ b/variables.tf
@@ -154,19 +154,7 @@ variable "apim_management_host_name" {
 variable "apim_management_key_vault_id" {
   type        = string
   description = "The ID of the Azure Key Vault secret containing the certificate"
-  default     = ""
-}
-
-variable "apim_management_certificate" {
-  type        = string
-  description = "The Base64 Encoded Certificate"
-  default     = ""
-}
-
-variable "apim_management_certificate_password" {
-  type        = string
-  description = "The password associated with the certificate provided above"
-  default     = ""
+  default     = "-"
 }
 
 variable "apim_management_negotiate_client_certificate" {
@@ -184,19 +172,7 @@ variable "apim_portal_host_name" {
 variable "apim_portal_key_vault_id" {
   type        = string
   description = "The ID of the Azure Key Vault secret containing the certificate"
-  default     = ""
-}
-
-variable "apim_portal_certificate" {
-  type        = string
-  description = "The Base64 Encoded Certificate"
-  default     = ""
-}
-
-variable "apim_portal_certificate_password" {
-  type        = string
-  description = "The password associated with the certificate provided above"
-  default     = ""
+  default     = "-"
 }
 
 variable "apim_portal_negotiate_client_certificate" {
@@ -211,22 +187,10 @@ variable "apim_developer_portal_host_name" {
   default     = ""
 }
 
-variable "apim_developer_portal_certificate" {
-  type        = string
-  description = "The Base64 Encoded Certificate"
-  default     = ""
-}
-
 variable "apim_developer_portal_key_vault_id" {
   type        = string
   description = "The ID of the Azure Key Vault secret containing the certificate"
-  default     = ""
-}
-
-variable "apim_developer_portal_certificate_password" {
-  type        = string
-  description = "The password associated with the certificate provided above"
-  default     = ""
+  default     = "-"
 }
 
 variable "apim_developer_portal_negotiate_client_certificate" {
@@ -244,19 +208,7 @@ variable "apim_scm_host_name" {
 variable "apim_scm_key_vault_id" {
   type        = string
   description = "The ID of the Azure Key Vault secret containing the certificate"
-  default     = ""
-}
-
-variable "apim_scm_certificate" {
-  type        = string
-  description = "The Base64 Encoded Certificate"
-  default     = ""
-}
-
-variable "apim_scm_certificate_password" {
-  type        = string
-  description = "The password associated with the certificate provided above"
-  default     = ""
+  default     = "-"
 }
 
 variable "apim_scm_negotiate_client_certificate" {

--- a/variables.tf
+++ b/variables.tf
@@ -268,3 +268,15 @@ variable "apim_scm_negotiate_client_certificate" {
 variable "module_depends_on" {
   default = [""]
 }
+
+variable "apim_key_vault_name" {
+  type        = string
+  description = "The name of the source Azure Key Vault"
+  default     = ""
+}
+
+variable "apim_key_vault_resource_group_name" {
+  type        = string
+  description = "The name of the resource group containing the source Azure Key Vault"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -269,6 +269,12 @@ variable "module_depends_on" {
   default = [""]
 }
 
+variable "apim_key_vault_enabled" {
+  type        = string
+  description = "Is Azure Key Vault enabled for certificate use"
+  default     = false
+}
+
 variable "apim_key_vault_name" {
   type        = string
   description = "The name of the source Azure Key Vault"


### PR DESCRIPTION
Adds a Key Vault certificate to the complete example.

APIM has preview support for UserAssigned managed identities. You can create and assign these using the `azurerm` Terraform provider, however, it doesn't seem to use them for Key Vault access only backend access.

Therefore you have to use a SystemAssigned managed identity. The SystemAssigned managed identity if created dynamically at APIM deployment time and cannot be created ahead of time. This means you cannot pass Azure Key Vault references directly to the APIM service deployment resource as it won't have access. The host_configuration block in APIM is not a separate resource so you cannot configure this post APIM deployment using an additional TF resource. Instead you have to use a script to apply the host configuration changes with the KV references via a script.
This change adds this functionality. The script will fetch the existing host configuration and then merge in the latest local configuration - conflicts will be overridden by the local config. Support for UserAssigned MSIs for KV access will hopefully be resolved at some point in the future and this should be removed.

APIM certificates (non kv) are still configured in the APIM resource block.

Prefix is also removed from APIM naming as this is incompatible.

Modifications to any host configuration variables will force a rerun of the script.

NOTE: I did see a case where the configuration was deployed successfully, modified and redeployed and it removed the KV access policy for the MSI but left it in TF state. This may be a bug but I haven't been able to reproduce it.
I've also changed the certificate from a self signed cert using Terraform TLS provider to using Azure Key Vault certificates as these are `"application/x-pkcs12"` compatible which is required by APIM.